### PR TITLE
Employ lazy logging facilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ UTILS_PATH := build_utils
 # with handling of the varriable in build_utils is fixed
 TEMPLATES_PATH := .
 SERVICE_NAME := scoper
-BUILD_IMAGE_TAG := cd38c35976f3684fe7552533b6175a4c3460e88b
+
+BUILD_IMAGE_NAME := build-erlang
+BUILD_IMAGE_TAG := 2ea61e9556ad67d5918f060ed50353662ed84e59
 
 CALL_W_CONTAINER := all submodules rebar-update compile xref lint \
 					dialyze test clean distclean check_format format
@@ -54,4 +56,3 @@ check_format:
 
 format:
 	$(REBAR) fmt -w
-

--- a/elvis.config
+++ b/elvis.config
@@ -2,26 +2,26 @@
     {elvis, [
         {config, [
             #{
-                dirs => ["src", "test"],
+                dirs => ["src"],
                 filter => "*.erl",
+                ruleset => erl_files,
                 rules => [
-                    {elvis_style, line_length, #{limit => 120, skip_comments => false}},
-                    {elvis_style, no_tabs},
-                    {elvis_style, no_trailing_whitespace},
-                    {elvis_style, macro_module_names},
-                    {elvis_style, operator_spaces, #{rules => [{right, ","}, {right, "++"}, {left, "++"}]}},
-                    {elvis_style, nesting_level, #{level => 3}},
-                    {elvis_style, god_modules, #{limit => 25}},
-                    {elvis_style, no_if_expression},
-                    {elvis_style, invalid_dynamic_call, #{ignore => [elvis, scoper_tests_SUITE]}},
-                    {elvis_style, used_ignored_variable},
-                    {elvis_style, no_behavior_info},
-                    {elvis_style, module_naming_convention, #{regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$"}},
-                    {elvis_style, function_naming_convention, #{regex => "^([a-z][a-z0-9]*_?)*$"}},
-                    {elvis_style, state_record_and_type},
-                    {elvis_style, no_spec_with_records},
-                    {elvis_style, dont_repeat_yourself, #{min_complexity => 10}},
-                    {elvis_style, no_debug_call, #{ignore => [elvis, elvis_utils]}}
+                    {elvis_text_style, line_length, #{limit => 120}}
+                ]
+            },
+            #{
+                dirs => ["test"],
+                filter => "*.erl",
+                ruleset => erl_files,
+                rules => [
+                    % We want to use `ct:pal/2` and friends in test code.
+                    {elvis_style, no_debug_call, disable},
+                    % Assert macros can trigger use of ignored binding, yet we want them for better
+                    % readability.
+                    {elvis_style, used_ignored_variable, disable},
+                    % Tests are usually more comprehensible when a bit more verbose.
+                    {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
+                    {elvis_text_style, line_length, #{limit => 120}}
                 ]
             },
             #{
@@ -31,25 +31,20 @@
             },
             #{
                 dirs => ["."],
-                filter => "elvis.config",
-                ruleset => elvis_config
-            },
-            #{
-                dirs => ["."],
                 filter => "rebar.config",
                 rules => [
-                    {elvis_style, line_length, #{limit => 120, skip_comments => false}},
-                    {elvis_style, no_tabs},
-                    {elvis_style, no_trailing_whitespace}
+                    {elvis_text_style, line_length, #{limit => 120}},
+                    {elvis_text_style, no_tabs},
+                    {elvis_text_style, no_trailing_whitespace}
                 ]
             },
             #{
                 dirs => ["src"],
                 filter => "*.app.src",
                 rules => [
-                    {elvis_style, line_length, #{limit => 120, skip_comments => false}},
-                    {elvis_style, no_tabs},
-                    {elvis_style, no_trailing_whitespace}
+                    {elvis_text_style, line_length, #{limit => 120}},
+                    {elvis_text_style, no_tabs},
+                    {elvis_text_style, no_trailing_whitespace}
                 ]
             }
         ]}

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,5 @@
 %% Common project erlang options.
 {erl_opts, [
-
     % mandatory
     debug_info,
     warnings_as_errors,
@@ -31,7 +30,6 @@
     deprecated_functions
 ]}.
 
-
 %% Tests
 {cover_enabled, true}.
 
@@ -53,14 +51,29 @@
 
 {profiles, [
     {test, [
+        {thrift_compiler_opts, [
+            {in_dir, "test"},
+            {in_files, ["test.thrift"]},
+            {out_erl_dir, "test"},
+            {out_hrl_dir, "test"},
+            {gen, "erlang:app_prefix=scp"}
+        ]},
+        {provider_hooks, [
+            {pre, [
+                {compile, {thrift, compile}},
+                {clean, {thrift, clean}}
+            ]}
+        ]},
         {deps, [
             {lager, "3.2.1"},
+            {genlib, {git, "https://github.com/rbkmoney/genlib.git", {branch, "master"}}},
             {woody, {git, "https://github.com/rbkmoney/woody_erlang.git", {branch, "master"}}}
         ]}
     ]}
 ]}.
 
 {plugins, [
+    {rebar3_thrift_compiler, {git, "https://github.com/rbkmoney/rebar3_thrift_compiler.git", {tag, "0.3.1"}}},
     {erlfmt, "0.8.0"}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -33,22 +33,6 @@
 %% Tests
 {cover_enabled, true}.
 
-%% Dialyzer static analyzing
-{dialyzer, [
-    {warnings, [
-        % mandatory
-        unmatched_returns,
-        error_handling,
-        race_conditions,
-        unknown
-    ]},
-    {plt_apps, all_deps},
-    {plt_extra_apps, [
-        lager,
-        woody
-    ]}
-]}.
-
 {profiles, [
     {test, [
         {thrift_compiler_opts, [
@@ -68,6 +52,24 @@
             {lager, "3.2.1"},
             {genlib, {git, "https://github.com/rbkmoney/genlib.git", {branch, "master"}}},
             {woody, {git, "https://github.com/rbkmoney/woody_erlang.git", {branch, "master"}}}
+        ]},
+        {dialyzer, [
+            {warnings, [
+                % mandatory
+                unmatched_returns,
+                error_handling,
+                race_conditions,
+                unknown
+            ]},
+            {plt_apps, all_deps},
+            {plt_extra_apps, [
+                lager,
+                woody,
+                genlib,
+                snowflake,
+                common_test,
+                public_key
+            ]}
         ]}
     ]}
 ]}.

--- a/src/scoper_woody_event_handler.erl
+++ b/src/scoper_woody_event_handler.erl
@@ -21,17 +21,13 @@
     Meta :: woody_event_handler:event_meta(),
     Opts :: options().
 %% client scoping
-handle_event(Event = 'client begin', RpcID, RawMeta, Opts) ->
-    ok = scoper:add_scope(get_scope_name(client)),
-    do_handle_event(Event, RpcID, RawMeta, Opts);
-handle_event(Event = 'client cache begin', RpcID, RawMeta, Opts) ->
-    ok = scoper:add_scope(get_scope_name(caching_client)),
-    do_handle_event(Event, RpcID, RawMeta, Opts);
-handle_event(Event = 'client end', RpcID, RawMeta, Opts) ->
-    ok = do_handle_event(Event, RpcID, RawMeta, Opts),
+handle_event('client begin', _RpcID, _Meta, _Opts) ->
+    scoper:add_scope(get_scope_name(client));
+handle_event('client cache begin', _RpcID, _Meta, _Opts) ->
+    scoper:add_scope(get_scope_name(caching_client));
+handle_event('client end', _RpcID, _Meta, _Opts) ->
     scoper:remove_scope();
-handle_event(Event = 'client cache end', RpcID, RawMeta, Opts) ->
-    ok = do_handle_event(Event, RpcID, RawMeta, Opts),
+handle_event('client cache end', _RpcID, _Meta, _Opts) ->
     scoper:remove_scope();
 %% server scoping
 handle_event(Event = 'server receive', RpcID, RawMeta, Opts) ->
@@ -61,25 +57,31 @@ handle_event(Event, RpcID, RawMeta, Opts) ->
 %%
 %% Internal functions
 %%
-do_handle_event(Event, _RpcID, _RawMeta, _Opts) when
-    Event =:= 'client begin' orelse
-        Event =:= 'client end' orelse
-        Event =:= 'client cache begin' orelse
-        Event =:= 'client cache end'
-->
-    ok;
-do_handle_event(Event, RpcID, RawMeta = #{role := Role}, Opts) ->
-    {Level, {Format, Args}, Meta} = woody_event_handler:format_event_and_meta(
-        Event,
-        RawMeta,
-        RpcID,
-        [event, service, function, type, metadata, url, deadline, execution_duration_ms],
-        get_event_handler_options(Opts)
-    ),
+
+-define(REQUISITE_META, [
+    event,
+    service,
+    function,
+    type,
+    metadata,
+    url,
+    deadline,
+    execution_duration_ms
+]).
+
+do_handle_event(Event, RpcID, EvMeta = #{role := Role}, Opts) ->
+    Level = woody_event_handler:get_event_severity(Event, EvMeta),
+    Meta = woody_event_handler:format_meta(Event, EvMeta, ?REQUISITE_META),
     ok = scoper:add_meta(Meta),
-    logger:log(Level, Format, Args, collect_md(Role, RpcID));
+    logger:log(Level, fun do_format_event/1, {Event, Role, EvMeta, RpcID, Opts});
 do_handle_event(_Event, _RpcID, _RawMeta, _Opts) ->
     ok.
+
+do_format_event({Event, Role, EvMeta, RpcID, Opts}) ->
+    EvHandlerOptions = get_event_handler_options(Opts),
+    Format = woody_event_handler:format_event(Event, EvMeta, EvHandlerOptions),
+    LogMeta = collect_md(Role, RpcID),
+    {Format, LogMeta}.
 
 %% Log metadata should contain rpc ID properties (trace_id, span_id and parent_id)
 %% _on the top level_ according to the requirements.

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+/scp_test_thrift*

--- a/test/scoper_event_handler_SUITE.erl
+++ b/test/scoper_event_handler_SUITE.erl
@@ -1,0 +1,224 @@
+-module(scoper_event_handler_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0]).
+-export([init_per_suite/1]).
+-export([end_per_suite/1]).
+
+-export([handler_logs_events/1]).
+
+%% woody_server callbacks
+-behaviour(woody_server_thrift_handler).
+
+-export([handle_function/4]).
+
+%% logger callbacks
+-export([log/2]).
+-export([adding_handler/1]).
+-export([removing_handler/1]).
+
+%%
+
+-type test_name() :: atom().
+-type config() :: [{atom(), _}].
+
+-spec all() -> [test_name()].
+all() ->
+    [
+        handler_logs_events
+    ].
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(C) ->
+    {ok, Apps1} = application:ensure_all_started(scoper),
+    {ok, Apps2} = application:ensure_all_started(woody),
+    ok = logger:set_primary_config(level, debug),
+    [{apps, Apps1 ++ Apps2} | C].
+
+-spec end_per_suite(config()) -> any().
+end_per_suite(C) ->
+    ok = logger:set_primary_config(level, notice),
+    [application:stop(App) || App <- ?config(apps, C)].
+
+%%
+
+-include("scp_test_thrift.hrl").
+
+-define(LOGEVENT(Level, Msg, Meta),
+    {log, #{
+        level := Level,
+        msg := {Msg, _},
+        meta := #{trace_id := <<_/binary>>, parent_id := <<_/binary>>, span_id := <<_/binary>>},
+        meta := Meta
+    }}
+).
+
+-spec handler_logs_events(config()) -> _.
+handler_logs_events(_C) ->
+    %% NOTE
+    %% Test that scoper properly handles woody events.
+    %% The purpose is to catch regressions early against woody master.
+    ServerId = ?FUNCTION_NAME,
+    HandlerId = ?FUNCTION_NAME,
+    {ok, Pid, Url} = start_woody_server(ServerId),
+    ok = logger:add_handler(HandlerId, ?MODULE, #{
+        level => debug,
+        config => #{forward => self()},
+        %% NOTE
+        %% Filter out everything spit out by OTP facilities: supervisor and progress reports, etc.
+        filters => [{domain, {fun logger_filters:domain/2, {stop, sub, [otp]}}}]
+    }),
+    {ok, #'GeneratedID'{}} = call_woody_service('GenerateID', {{snowflake, #'SnowflakeSchema'{}}}, Url),
+    ok = stop_woody_server(Pid),
+    ok = logger:remove_handler(HandlerId),
+    ?assertMatch(
+        [
+            {relay, HandlerId, started},
+            {relay, HandlerId,
+                ?LOGEVENT(info, "[client] calling" ++ _, #{
+                    'rpc.client' := #{
+                        event := 'call service',
+                        function := 'GenerateID',
+                        service := 'Generator'
+                    }
+                })},
+            {relay, HandlerId,
+                ?LOGEVENT(debug, "[client] sending request" ++ _, #{
+                    'rpc.client' := #{
+                        event := 'client send',
+                        type := call,
+                        url := Url,
+                        function := 'GenerateID',
+                        service := 'Generator'
+                    }
+                })},
+            {relay, HandlerId,
+                ?LOGEVENT(debug, "[server] request" ++ _, #{
+                    'rpc.server' := #{
+                        event := 'server receive',
+                        url := Url
+                    }
+                })},
+            {relay, HandlerId,
+                ?LOGEVENT(info, "[server] handling" ++ _, #{
+                    'rpc.server' := #{
+                        event := 'invoke service handler',
+                        url := Url,
+                        type := call,
+                        function := 'GenerateID',
+                        service := 'Generator'
+                    }
+                })},
+            {relay, HandlerId,
+                ?LOGEVENT(info, "[server] handling result" ++ _, #{
+                    'rpc.server' := #{
+                        event := 'service handler result',
+                        url := Url,
+                        type := call,
+                        function := 'GenerateID',
+                        service := 'Generator'
+                    }
+                })},
+            {relay, HandlerId,
+                ?LOGEVENT(debug, "[server] response sent" ++ _, #{
+                    'rpc.server' := #{
+                        event := 'server send',
+                        url := Url,
+                        type := call,
+                        function := 'GenerateID',
+                        service := 'Generator',
+                        execution_duration_ms := _
+                    }
+                })},
+            {relay, HandlerId,
+                ?LOGEVENT(debug, "[client] received response" ++ _, #{
+                    'rpc.client' := #{
+                        event := 'client receive',
+                        url := Url,
+                        type := call,
+                        function := 'GenerateID',
+                        service := 'Generator',
+                        execution_duration_ms := _
+                    }
+                })},
+            {relay, HandlerId,
+                ?LOGEVENT(info, "[client] request handled" ++ _, #{
+                    'rpc.client' := #{
+                        event := 'service result',
+                        url := Url,
+                        type := call,
+                        function := 'GenerateID',
+                        service := 'Generator',
+                        execution_duration_ms := _
+                    }
+                })},
+            {relay, HandlerId, terminated}
+        ],
+        flush_msg_queue(1000)
+    ).
+
+flush_msg_queue(Timeout) ->
+    receive
+        M -> [M | flush_msg_queue(Timeout)]
+    after Timeout -> []
+    end.
+
+%%
+
+-define(SERVICE, {scp_test_thrift, 'Generator'}).
+
+start_woody_server(Id) ->
+    Path = "/gen",
+    ServerOpts = #{
+        handlers => [{Path, {?SERVICE, ?MODULE}}],
+        event_handler => scoper_woody_event_handler,
+        ip => {127, 0, 0, 1},
+        port => 0
+    },
+    {ok, SupPid} = genlib_adhoc_supervisor:start_link(#{}, [woody_server:child_spec(Id, ServerOpts)]),
+    {IP, Port} = woody_server:get_addr(Id, ServerOpts),
+    Url = genlib:format("http://~s:~p~s", [inet:ntoa(IP), Port, Path]),
+    {ok, SupPid, Url}.
+
+stop_woody_server(SupPid) ->
+    true = erlang:unlink(SupPid),
+    proc_lib:stop(SupPid, shutdown, 1000).
+
+call_woody_service(Function, Args, Url) ->
+    Request = {?SERVICE, Function, Args},
+    woody_client:call(Request, #{url => Url, event_handler => scoper_woody_event_handler}).
+
+-spec handle_function(woody:func(), woody:args(), woody_context:ctx(), woody:options()) ->
+    {ok, woody:result()} | no_return().
+handle_function('GenerateID', {Schema}, _WoodyCtx, _Opts) ->
+    {ID, IntegerID} = generate_id(Schema),
+    {ok, #'GeneratedID'{id = ID, integer_id = IntegerID}}.
+
+generate_id({snowflake, _}) ->
+    <<ID:64>> = snowflake:new(),
+    {genlib_format:format_int_base(ID, 62), ID};
+generate_id({sequence, _}) ->
+    ID = erlang:unique_integer([positive, monotonic]),
+    {integer_to_binary(ID), ID}.
+
+%% NOTE
+%% Logger handler which forwards every log message to the configured process.
+
+-spec log(logger:log_event(), logger:handler_config()) -> ok.
+log(LogEvent, #{id := Name, module := ?MODULE, config := Config}) ->
+    Pid = maps:get(forward, Config),
+    Pid ! {relay, Name, {log, LogEvent}},
+    ok.
+
+-spec adding_handler(logger:handler_config()) -> {ok, logger:handler_config()}.
+adding_handler(HConfig = #{id := Name, module := ?MODULE, config := Config}) ->
+    Pid = maps:get(forward, Config),
+    Pid ! {relay, Name, started},
+    {ok, HConfig}.
+
+-spec removing_handler(logger:handler_config()) -> _.
+removing_handler(#{id := Name, module := ?MODULE, config := Config}) ->
+    Pid = maps:get(forward, Config),
+    Pid ! {relay, Name, terminated}.

--- a/test/scoper_tests_SUITE.erl
+++ b/test/scoper_tests_SUITE.erl
@@ -23,7 +23,7 @@
 %%
 %% Tests descriptions
 %%
--spec all() -> [test_name()].
+-spec all() -> [{group, group_name()}].
 all() ->
     [
         {group, procdict},
@@ -96,12 +96,12 @@ mirror_scoper_state_in_meta([Scope | NextScopes], State) ->
     ),
     ok = match_scoper_state_and_meta(State).
 
--spec play_with_meta(config()) -> ok.
+-spec play_with_meta(config()) -> _.
 play_with_meta(_C) ->
     %% Try to operate on non initilized scopes
     ok = scoper:add_meta(#{dummy => dummy}),
     #{} = scoper:collect(),
-    ok = scoper:remove_meta(dummy),
+    ok = scoper:remove_meta([dummy]),
     #{} = scoper:collect(),
 
     %% Create scope1 and add key1
@@ -168,7 +168,7 @@ play_with_meta(_C) ->
     %% Try to operate when no scopes are there
     ok = scoper:add_meta(#{dummy => dummy}),
     #{} = scoper:collect(),
-    ok = scoper:remove_meta(dummy),
+    ok = scoper:remove_meta([dummy]),
     #{} = scoper:collect(),
 
     %% Add scopes and clear them all
@@ -188,7 +188,7 @@ match_scoper_state_and_meta(State) ->
 match_scoper_state_and_meta([], #{}) ->
     ok;
 match_scoper_state_and_meta(State, Data = #{?TAG := State}) ->
-    lists:foldr(
+    _ = lists:foldr(
         fun(Scope, Acc) ->
             do_match_scoper_state_and_meta(Scope, [Scope | Acc], Data)
         end,

--- a/test/test.thrift
+++ b/test/test.thrift
@@ -1,0 +1,26 @@
+namespace erlang scp
+
+typedef string ExternalID
+typedef string InternalID
+typedef i64    IntegerInternalID
+
+struct GeneratedID {
+    1: required InternalID id
+    2: optional IntegerInternalID integer_id
+}
+
+union GenerationSchema {
+    1: SnowflakeSchema snowflake
+    3: SequenceSchema sequence
+}
+
+struct SnowflakeSchema {}
+
+struct SequenceSchema {
+    1: required string sequence_id
+    2: optional i64 minimum
+}
+
+service Generator {
+    GeneratedID GenerateID (1: GenerationSchema schema)
+}


### PR DESCRIPTION
In order to shed some extra work (e.g. formatting thrift message) when a log event is deemed to miss logs, due to log level being too verbose for example.

Depends on rbkmoney/woody_erlang#152.